### PR TITLE
Fixed spelling error - 'Sbujects' to 'Subjects'

### DIFF
--- a/de_school/i18n/ar.po
+++ b/de_school/i18n/ar.po
@@ -1147,12 +1147,12 @@ msgstr "الغرف"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_batch_form_view
-msgid "Sbujects"
+msgid "Subjects"
 msgstr "المواضيع"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_form_view
-msgid "Sbujects Assignment"
+msgid "Subjects Assignment"
 msgstr "تعيين المواد"
 
 #. module: de_school

--- a/de_school/i18n/ar_001.po
+++ b/de_school/i18n/ar_001.po
@@ -1147,12 +1147,12 @@ msgstr "الغرف"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_batch_form_view
-msgid "Sbujects"
+msgid "Subjects"
 msgstr "المواضيع"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_form_view
-msgid "Sbujects Assignment"
+msgid "Subjects Assignment"
 msgstr "تعيين المواد"
 
 #. module: de_school

--- a/de_school/i18n/de_school.pot
+++ b/de_school/i18n/de_school.pot
@@ -1147,12 +1147,12 @@ msgstr "الغرف"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_batch_form_view
-msgid "Sbujects"
+msgid "Subjects"
 msgstr "المواضيع"
 
 #. module: de_school
 #: model_terms:ir.ui.view,arch_db:de_school.school_course_form_view
-msgid "Sbujects Assignment"
+msgid "Subjects Assignment"
 msgstr "تعيين المواد"
 
 #. module: de_school

--- a/de_school/views/.ipynb_checkpoints/batch_views-checkpoint.xml
+++ b/de_school/views/.ipynb_checkpoints/batch_views-checkpoint.xml
@@ -36,7 +36,7 @@
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                         <notebook>
-                            <page string="Sbujects">
+                            <page string="Subjects">
                                 <field name="subject_ids" widget="one2many_list" readonly="1">
 									<tree >
 										<field name="name" />

--- a/de_school/views/.ipynb_checkpoints/course_views-checkpoint.xml
+++ b/de_school/views/.ipynb_checkpoints/course_views-checkpoint.xml
@@ -66,7 +66,7 @@
                             <field name="company_id" options="{'no_create': True}" />
                         </group>
 						<notebook>
-                            <page string="Sbujects">
+                            <page string="Subjects">
                                 <field name="subject_ids" widget="one2many_list" readonly="1">
 									<tree editable ="top" >
 										<field name="name" />

--- a/de_school/views/batch_views.xml
+++ b/de_school/views/batch_views.xml
@@ -42,7 +42,7 @@
                             </group>
                         </group>
                         <notebook>
-                            <page string="Sbujects" invisible="not count_subjects">
+                            <page string="Subjects" invisible="not count_subjects">
                                 <field name="subject_ids" widget="one2many_list" readonly="1">
 									<tree >
 										<field name="name" />

--- a/de_school/views/course_views.xml
+++ b/de_school/views/course_views.xml
@@ -93,7 +93,7 @@
                             </group>
                         </group>
 						<notebook>
-                            <page string="Sbujects Assignment">
+                            <page string="Subjects Assignment">
                                 <field name="course_subject_line" >
 									<tree editable ="bottom" >
                                         <field name="course_id" column_invisible="1" />


### PR DESCRIPTION
I noticed the problem here:

![image](https://github.com/user-attachments/assets/99441be8-3eac-4795-9f35-90484a490602)
